### PR TITLE
test: make mock server name lookups case-insensitive

### DIFF
--- a/crowd-mock-server/db/migrate.go
+++ b/crowd-mock-server/db/migrate.go
@@ -10,7 +10,7 @@ import (
 const schema = `
 CREATE TABLE IF NOT EXISTS users (
     id            BIGSERIAL PRIMARY KEY,
-    name          TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL,
     key           TEXT NOT NULL UNIQUE,
     first_name    TEXT NOT NULL DEFAULT '',
     last_name     TEXT NOT NULL DEFAULT '',
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE TABLE IF NOT EXISTS groups (
     id            BIGSERIAL PRIMARY KEY,
-    name          TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL,
     description   TEXT NOT NULL DEFAULT '',
     active        BOOLEAN NOT NULL DEFAULT TRUE,
     type          TEXT NOT NULL DEFAULT 'GROUP',
@@ -38,6 +38,8 @@ CREATE TABLE IF NOT EXISTS user_attributes (
     attr_name  TEXT NOT NULL,
     attr_value TEXT NOT NULL
 );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_name_ci ON users(LOWER(name));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_groups_name_ci ON groups(LOWER(name));
 CREATE INDEX IF NOT EXISTS idx_user_attr_user_id ON user_attributes(user_id);
 
 CREATE TABLE IF NOT EXISTS group_attributes (

--- a/crowd-mock-server/handler/group.go
+++ b/crowd-mock-server/handler/group.go
@@ -50,7 +50,7 @@ func (h *GroupHandler) HandleCreateGroup(w http.ResponseWriter, r *http.Request)
 	// Store attributes if provided
 	if group.Attributes != nil {
 		var groupID int64
-		err := h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE name=$1`, group.Name).Scan(&groupID)
+		err := h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE LOWER(name) = LOWER($1)`, group.Name).Scan(&groupID)
 		if err != nil {
 			model.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
 			return
@@ -76,7 +76,7 @@ func (h *GroupHandler) HandleGetGroup(w http.ResponseWriter, r *http.Request) {
 	var group model.GroupEntity
 	var id int64
 	err := h.Pool.QueryRow(ctx,
-		`SELECT id, name, description, active, type FROM groups WHERE name=$1`, groupname,
+		`SELECT id, name, description, active, type FROM groups WHERE LOWER(name) = LOWER($1)`, groupname,
 	).Scan(&id, &group.Name, &group.Description, &group.Active, &group.Type)
 
 	if err == pgx.ErrNoRows {
@@ -117,7 +117,7 @@ func (h *GroupHandler) HandleUpdateGroup(w http.ResponseWriter, r *http.Request)
 
 	now := time.Now().UnixMilli()
 	result, err := h.Pool.Exec(r.Context(),
-		`UPDATE groups SET description=$1, active=$2, updated_date=$3 WHERE name=$4`,
+		`UPDATE groups SET description=$1, active=$2, updated_date=$3 WHERE LOWER(name) = LOWER($4)`,
 		group.Description, group.Active, now, groupname,
 	)
 	if err != nil {
@@ -139,7 +139,7 @@ func (h *GroupHandler) HandleDeleteGroup(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	result, err := h.Pool.Exec(r.Context(), `DELETE FROM groups WHERE name=$1`, groupname)
+	result, err := h.Pool.Exec(r.Context(), `DELETE FROM groups WHERE LOWER(name) = LOWER($1)`, groupname)
 	if err != nil {
 		model.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
 		return
@@ -167,7 +167,7 @@ func (h *GroupHandler) HandleStoreGroupAttributes(w http.ResponseWriter, r *http
 
 	ctx := r.Context()
 	var groupID int64
-	err := h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE name=$1`, groupname).Scan(&groupID)
+	err := h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE LOWER(name) = LOWER($1)`, groupname).Scan(&groupID)
 	if err == pgx.ErrNoRows {
 		model.WriteError(w, http.StatusNotFound, "GROUP_NOT_FOUND",
 			fmt.Sprintf("Group <%s> does not exist", groupname))
@@ -202,7 +202,7 @@ func (h *GroupHandler) HandleAddChildGroup(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	var parentID, childID int64
 
-	err := h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE name=$1`, parentName).Scan(&parentID)
+	err := h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE LOWER(name) = LOWER($1)`, parentName).Scan(&parentID)
 	if err == pgx.ErrNoRows {
 		model.WriteError(w, http.StatusNotFound, "GROUP_NOT_FOUND",
 			fmt.Sprintf("Group <%s> does not exist", parentName))
@@ -213,7 +213,7 @@ func (h *GroupHandler) HandleAddChildGroup(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err = h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE name=$1`, ref.Name).Scan(&childID)
+	err = h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE LOWER(name) = LOWER($1)`, ref.Name).Scan(&childID)
 	if err == pgx.ErrNoRows {
 		model.WriteError(w, http.StatusNotFound, "GROUP_NOT_FOUND",
 			fmt.Sprintf("Group <%s> does not exist", ref.Name))
@@ -247,8 +247,8 @@ func (h *GroupHandler) HandleRemoveChildGroup(w http.ResponseWriter, r *http.Req
 	ctx := r.Context()
 	_, err := h.Pool.Exec(ctx,
 		`DELETE FROM group_group_memberships
-		 WHERE parent_group_id = (SELECT id FROM groups WHERE name=$1)
-		   AND child_group_id = (SELECT id FROM groups WHERE name=$2)`,
+		 WHERE parent_group_id = (SELECT id FROM groups WHERE LOWER(name) = LOWER($1))
+		   AND child_group_id = (SELECT id FROM groups WHERE LOWER(name) = LOWER($2))`,
 		parentName, childName,
 	)
 	if err != nil {
@@ -276,7 +276,7 @@ func (h *GroupHandler) HandleGetParentGroups(w http.ResponseWriter, r *http.Requ
 		`SELECT pg.name FROM groups pg
 		 JOIN group_group_memberships ggm ON pg.id = ggm.parent_group_id
 		 JOIN groups cg ON cg.id = ggm.child_group_id
-		 WHERE cg.name = $1
+		 WHERE LOWER(cg.name) = LOWER($1)
 		 ORDER BY pg.name
 		 OFFSET $2 LIMIT $3`,
 		groupname, startIndex, maxResults,

--- a/crowd-mock-server/handler/user.go
+++ b/crowd-mock-server/handler/user.go
@@ -93,7 +93,7 @@ func (h *UserHandler) HandleGetUser(w http.ResponseWriter, r *http.Request) {
 	} else if username != "" {
 		err = h.Pool.QueryRow(ctx,
 			`SELECT id, name, key, first_name, last_name, display_name, email, active, created_date, updated_date
-			 FROM users WHERE name = $1`, username,
+			 FROM users WHERE LOWER(name) = LOWER($1)`, username,
 		).Scan(&id, &user.Name, &user.Key, &user.FirstName, &user.LastName,
 			&user.DisplayName, &user.Email, &user.Active, &user.CreatedDate, &user.UpdatedDate)
 	} else {
@@ -139,7 +139,7 @@ func (h *UserHandler) HandleUpdateUser(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UnixMilli()
 	result, err := h.Pool.Exec(r.Context(),
 		`UPDATE users SET first_name=$1, last_name=$2, display_name=$3, email=$4, active=$5, updated_date=$6
-		 WHERE name=$7`,
+		 WHERE LOWER(name) = LOWER($7)`,
 		user.FirstName, user.LastName, user.DisplayName, user.Email, user.Active, now, username,
 	)
 	if err != nil {
@@ -161,7 +161,7 @@ func (h *UserHandler) HandleDeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.Pool.Exec(r.Context(), `DELETE FROM users WHERE name=$1`, username)
+	result, err := h.Pool.Exec(r.Context(), `DELETE FROM users WHERE LOWER(name) = LOWER($1)`, username)
 	if err != nil {
 		model.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
 		return
@@ -188,7 +188,7 @@ func (h *UserHandler) HandleUpdatePassword(w http.ResponseWriter, r *http.Reques
 	}
 
 	result, err := h.Pool.Exec(r.Context(),
-		`UPDATE users SET password=$1, updated_date=$2 WHERE name=$3`,
+		`UPDATE users SET password=$1, updated_date=$2 WHERE LOWER(name) = LOWER($3)`,
 		cred.Value, time.Now().UnixMilli(), username,
 	)
 	if err != nil {
@@ -220,7 +220,7 @@ func (h *UserHandler) HandleRenameUser(w http.ResponseWriter, r *http.Request) {
 
 	now := time.Now().UnixMilli()
 	result, err := h.Pool.Exec(r.Context(),
-		`UPDATE users SET name=$1, updated_date=$2 WHERE name=$3`,
+		`UPDATE users SET name=$1, updated_date=$2 WHERE LOWER(name) = LOWER($3)`,
 		newName, now, username,
 	)
 	if err != nil {
@@ -242,7 +242,7 @@ func (h *UserHandler) HandleRenameUser(w http.ResponseWriter, r *http.Request) {
 	var user model.UserEntity
 	err = h.Pool.QueryRow(r.Context(),
 		`SELECT name, key, first_name, last_name, display_name, email, active, created_date, updated_date
-		 FROM users WHERE name = $1`, newName,
+		 FROM users WHERE LOWER(name) = LOWER($1)`, newName,
 	).Scan(&user.Name, &user.Key, &user.FirstName, &user.LastName,
 		&user.DisplayName, &user.Email, &user.Active, &user.CreatedDate, &user.UpdatedDate)
 	if err != nil {
@@ -267,7 +267,7 @@ func (h *UserHandler) HandleStoreUserAttributes(w http.ResponseWriter, r *http.R
 
 	ctx := r.Context()
 	var userID int64
-	err := h.Pool.QueryRow(ctx, `SELECT id FROM users WHERE name=$1`, username).Scan(&userID)
+	err := h.Pool.QueryRow(ctx, `SELECT id FROM users WHERE LOWER(name) = LOWER($1)`, username).Scan(&userID)
 	if err == pgx.ErrNoRows {
 		model.WriteError(w, http.StatusNotFound, "USER_NOT_FOUND",
 			fmt.Sprintf("User <%s> does not exist", username))
@@ -302,7 +302,7 @@ func (h *UserHandler) HandleAddUserToGroup(w http.ResponseWriter, r *http.Reques
 
 	ctx := r.Context()
 	var userID, groupID int64
-	err := h.Pool.QueryRow(ctx, `SELECT id FROM users WHERE name=$1`, userRef.Name).Scan(&userID)
+	err := h.Pool.QueryRow(ctx, `SELECT id FROM users WHERE LOWER(name) = LOWER($1)`, userRef.Name).Scan(&userID)
 	if err == pgx.ErrNoRows {
 		model.WriteError(w, http.StatusNotFound, "USER_NOT_FOUND",
 			fmt.Sprintf("User <%s> does not exist", userRef.Name))
@@ -313,7 +313,7 @@ func (h *UserHandler) HandleAddUserToGroup(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err = h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE name=$1`, groupname).Scan(&groupID)
+	err = h.Pool.QueryRow(ctx, `SELECT id FROM groups WHERE LOWER(name) = LOWER($1)`, groupname).Scan(&groupID)
 	if err == pgx.ErrNoRows {
 		model.WriteError(w, http.StatusNotFound, "GROUP_NOT_FOUND",
 			fmt.Sprintf("Group <%s> does not exist", groupname))
@@ -348,8 +348,8 @@ func (h *UserHandler) HandleRemoveUserFromGroup(w http.ResponseWriter, r *http.R
 	ctx := r.Context()
 	_, err := h.Pool.Exec(ctx,
 		`DELETE FROM user_group_memberships
-		 WHERE user_id = (SELECT id FROM users WHERE name=$1)
-		   AND group_id = (SELECT id FROM groups WHERE name=$2)`,
+		 WHERE user_id = (SELECT id FROM users WHERE LOWER(name) = LOWER($1))
+		   AND group_id = (SELECT id FROM groups WHERE LOWER(name) = LOWER($2))`,
 		username, groupname,
 	)
 	if err != nil {
@@ -377,7 +377,7 @@ func (h *UserHandler) HandleGetGroupsForUser(w http.ResponseWriter, r *http.Requ
 		`SELECT g.name FROM groups g
 		 JOIN user_group_memberships ugm ON g.id = ugm.group_id
 		 JOIN users u ON u.id = ugm.user_id
-		 WHERE u.name = $1
+		 WHERE LOWER(u.name) = LOWER($1)
 		 ORDER BY g.name
 		 OFFSET $2 LIMIT $3`,
 		username, startIndex, maxResults,

--- a/src/test/java/jp/openstandia/connector/crowd/integration/GroupIT.java
+++ b/src/test/java/jp/openstandia/connector/crowd/integration/GroupIT.java
@@ -418,6 +418,107 @@ class GroupIT extends AbstractIntegrationTest {
         assertNull(result);
     }
 
+    // --- Lifecycle ---
+
+    @Test
+    void groupLifecycle() {
+        // Create
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(new Name("lifecycle-group"));
+        attrs.add(AttributeBuilder.buildEnabled(true));
+        attrs.add(AttributeBuilder.build("description", "initial desc"));
+        Uid uid = connector.create(GROUP_OBJECT_CLASS, attrs, new OperationOptionsBuilder().build());
+
+        assertNotNull(uid);
+        assertEquals("lifecycle-group", uid.getUidValue());
+
+        // Get by UID
+        ConnectorObject result = connector.getObject(GROUP_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-group")), defaultGetOperation());
+        assertEquals("initial desc", singleAttr(result, "description"));
+
+        // Update
+        Set<AttributeDelta> modifications = new HashSet<>();
+        modifications.add(AttributeDeltaBuilder.build("description", "updated desc"));
+        modifications.add(AttributeDeltaBuilder.buildEnabled(false));
+
+        connector.updateDelta(GROUP_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-group")), modifications, new OperationOptionsBuilder().build());
+
+        result = connector.getObject(GROUP_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-group")), defaultGetOperation());
+        assertEquals("updated desc", singleAttr(result, "description"));
+        assertEquals(false, singleAttr(result, OperationalAttributes.ENABLE_NAME));
+
+        // Delete
+        connector.delete(GROUP_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-group")), new OperationOptionsBuilder().build());
+
+        result = connector.getObject(GROUP_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-group")), defaultGetOperation());
+        assertNull(result);
+    }
+
+    // --- Case insensitive ---
+
+    @Test
+    void getGroupByUidCaseInsensitive() {
+        // Create group with mixed case
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(new Name("MyGroup"));
+        attrs.add(AttributeBuilder.buildEnabled(true));
+        attrs.add(AttributeBuilder.build("description", "mixed case group"));
+        Uid uid = connector.create(GROUP_OBJECT_CLASS, attrs, new OperationOptionsBuilder().build());
+
+        // Get by lowercase UID (MidPoint normalizes to lowercase due to STRING_CASE_IGNORE)
+        ConnectorObject result = connector.getObject(GROUP_OBJECT_CLASS,
+                new Uid("mygroup", new Name("mygroup")), defaultGetOperation());
+
+        assertNotNull(result, "Should find group with case-insensitive lookup");
+        assertEquals("mixed case group", singleAttr(result, "description"));
+    }
+
+    @Test
+    void updateGroupCaseInsensitive() {
+        // Create group with mixed case
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(new Name("TestGroup"));
+        attrs.add(AttributeBuilder.buildEnabled(true));
+        attrs.add(AttributeBuilder.build("description", "original"));
+        connector.create(GROUP_OBJECT_CLASS, attrs, new OperationOptionsBuilder().build());
+
+        // Update using lowercase UID
+        Set<AttributeDelta> modifications = new HashSet<>();
+        modifications.add(AttributeDeltaBuilder.build("description", "updated"));
+
+        connector.updateDelta(GROUP_OBJECT_CLASS,
+                new Uid("testgroup", new Name("testgroup")), modifications, new OperationOptionsBuilder().build());
+
+        // Verify update succeeded
+        ConnectorObject result = connector.getObject(GROUP_OBJECT_CLASS,
+                new Uid("testgroup", new Name("testgroup")), defaultGetOperation());
+        assertNotNull(result);
+        assertEquals("updated", singleAttr(result, "description"));
+    }
+
+    @Test
+    void deleteGroupCaseInsensitive() {
+        // Create group with mixed case
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(new Name("DeleteMe"));
+        attrs.add(AttributeBuilder.buildEnabled(true));
+        connector.create(GROUP_OBJECT_CLASS, attrs, new OperationOptionsBuilder().build());
+
+        // Delete using lowercase UID
+        connector.delete(GROUP_OBJECT_CLASS,
+                new Uid("deleteme", new Name("deleteme")), new OperationOptionsBuilder().build());
+
+        // Verify deleted
+        ConnectorObject result = connector.getObject(GROUP_OBJECT_CLASS,
+                new Uid("deleteme", new Name("deleteme")), defaultGetOperation());
+        assertNull(result);
+    }
+
     // --- Helpers ---
 
     private Uid createTestGroup(String name, String description) {

--- a/src/test/java/jp/openstandia/connector/crowd/integration/UserIT.java
+++ b/src/test/java/jp/openstandia/connector/crowd/integration/UserIT.java
@@ -481,6 +481,64 @@ class UserIT extends AbstractIntegrationTest {
         assertNull(result);
     }
 
+    // --- Lifecycle ---
+
+    @Test
+    void userLifecycle() {
+        // Create
+        Uid uid = createTestUser("lifecycle-user", "lc@example.com", "Lifecycle User", "Life", "Cycle");
+
+        assertNotNull(uid);
+        assertNotNull(uid.getUidValue());
+
+        // Get by UID
+        ConnectorObject result = connector.getObject(USER_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-user")), defaultGetOperation());
+        assertEquals("lifecycle-user", result.getName().getNameValue());
+        assertEquals("lc@example.com", singleAttr(result, "email"));
+        assertEquals("Lifecycle User", singleAttr(result, "display-name"));
+
+        // Update
+        Set<AttributeDelta> modifications = new HashSet<>();
+        modifications.add(AttributeDeltaBuilder.build("display-name", "Updated Name"));
+        modifications.add(AttributeDeltaBuilder.buildEnabled(false));
+
+        connector.updateDelta(USER_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-user")), modifications, new OperationOptionsBuilder().build());
+
+        result = connector.getObject(USER_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-user")), defaultGetOperation());
+        assertEquals("Updated Name", singleAttr(result, "display-name"));
+        assertEquals(false, singleAttr(result, OperationalAttributes.ENABLE_NAME));
+
+        // Delete
+        connector.delete(USER_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-user")), new OperationOptionsBuilder().build());
+
+        result = connector.getObject(USER_OBJECT_CLASS,
+                new Uid(uid.getUidValue(), new Name("lifecycle-user")), defaultGetOperation());
+        assertNull(result);
+    }
+
+    // --- Case insensitive ---
+
+    @Test
+    void getUserByNameCaseInsensitive() {
+        // Create user with mixed case
+        createTestUser("FooBar", "foobar@example.com", "Foo Bar", "Foo", "Bar");
+
+        // Search by lowercase name (MidPoint normalizes due to STRING_CASE_IGNORE)
+        List<ConnectorObject> results = new ArrayList<>();
+        ResultsHandler handler = connectorObject -> {
+            results.add(connectorObject);
+            return true;
+        };
+        connector.search(USER_OBJECT_CLASS, FilterBuilder.equalTo(new Name("foobar")), handler, defaultSearchOperation());
+
+        assertEquals(1, results.size());
+        assertEquals("foobar@example.com", singleAttr(results.get(0), "email"));
+    }
+
     // --- Helpers ---
 
     private Uid createTestUser(String name, String email, String displayName, String firstName, String lastName) {


### PR DESCRIPTION
Crowd treats user and group names as case-insensitive. The mock server was using exact match queries, causing 404 when MidPoint normalized names to lowercase.

Use LOWER() in all name-based SQL queries and replace column UNIQUE constraints with UNIQUE INDEX on LOWER(name).